### PR TITLE
setting file permissions on datastore directory

### DIFF
--- a/src/main/java/dswebquerytobigquery/Authorizer.java
+++ b/src/main/java/dswebquerytobigquery/Authorizer.java
@@ -96,6 +96,8 @@ class Authorizer {
     var datastoreDirectory = new File(Constants.CREDENTIAL_DATASTORE_FOLDER);
     //noinspection ResultOfMethodCallIgnored
     datastoreDirectory.mkdir();
+    datastoreDirectory.setWritable(true, true);
+    datastoreDirectory.setReadable(true, true);
 
     return new FileDataStoreFactory(datastoreDirectory);
   }


### PR DESCRIPTION
You are using the File API to create a directory ('datastore') which ultimately stores OAuth2 credentials. Utilizing methods on the File API, I was able to set the read and write permission on that directory to restrict the permission to the owner of the directory.  This change doesn't really fix the issue.

It *appears* as though the creation of the file which stores the credentials ('StoredCredentials') is being handled by the `[com.google.auth.oauth2.UserCredentials](https://googleapis.dev/java/google-auth-library/0.23.0/index.html)` Class.  I don't see any native capability to set file permissions in this library.

You might need to migrate to a different method of creating the 'StoredCredentials' file, one that allows more control of the StoredCredentials File or request an upgrade to the underlying library. 