### PR TITLE
Add a build target to include the Java main class in the jar manifest.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,14 @@ repositories {
     gradlePluginPortal()
 }
 
+jar {
+    manifest {
+        attributes(
+            'Main-Class': 'dswebquerytobigquery.Main'
+        )
+    }
+}
+
 def autoValueVersion = "1.9"
 def floggerVersion = "0.7.4"
 def guavaVersion = "31.1-jre"


### PR DESCRIPTION
Hello, after building the complete jar file, I was not able to run the jar file since the manifest did not contain an entry for the Java main class.  I think that section was left out of the build file.